### PR TITLE
Rename default metrics

### DIFF
--- a/cfg/defaults.yaml
+++ b/cfg/defaults.yaml
@@ -18,13 +18,13 @@ pages:
           - name: heating_circuit_pressure
             searchString: PRESSURE HTG CIRC
             description: pressure in heating in bar
-          - name: output_activity
+          - name: output_activity_ratio
             searchString: OUTPUT HP
             description: pump activity in percentage
             divisor: 100
             labels:
               pump: heat
-          - name: output_activity
+          - name: output_activity_ratio
             searchString: INT PUMP RATE
             description: pump activity in percentage
             divisor: 100

--- a/cfg/defaults.yaml
+++ b/cfg/defaults.yaml
@@ -196,14 +196,14 @@ pages:
             searchString: COMPRESSOR DHW DAY
             description: compressor energy in Ws
             labels:
-              compressor: dhw
+              compressor: domestic_hotwater
               timeframe: day
             multiplier: 3.6e+6
           - name: heating_total
             searchString: COMPRESSOR DHW TOTAL
             description: compressor energy in Ws
             labels:
-              compressor: dhw
+              compressor: domestic_hotwater
               timeframe: total
             multiplier: 3.6e+9
           - name: heating_total

--- a/cfg/defaults.yaml
+++ b/cfg/defaults.yaml
@@ -77,12 +77,12 @@ pages:
             searchString: DUAL MODE TEMP HEATING
             description: temperature in degree Celsius
             labels:
-              temperature: heating
+              sensor: heating
           - name: dualmode_reheating_temperature
             searchString: DUAL MODE TEMP DHW
             description: temperature in degree Celsius
             labels:
-              temperature: domestic_hotwater
+              sensor: domestic_hotwater
       heating:
         searchString: HEATING
         metrics:


### PR DESCRIPTION
## Summary

* Rename `stiebeleltron_general_output_activity` to `stiebeleltron_general_output_activity_ratio`
* Renames label value from `compressor` of `stiebeleltron_energy_heating_total` from `dhw` to `domestic_hotwater`
* Renames label key from of `stiebeleltron_electric_reheating_dualmode_reheating_temperature` from `temperature` to `sensor`

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
