### PR TITLE
Remove duplicate/wrong outside temperature metric

### DIFF
--- a/cfg/defaults.yaml
+++ b/cfg/defaults.yaml
@@ -5,9 +5,6 @@ pages:
       general:
         searchString: GENERAL
         metrics:
-          - name: temperature_outside
-            searchString: OUTSIDE TEMPERATURE
-            description: Outside temperature in degree Celsius
           - name: temperature_condenser
             searchString: CONDENSER TEMP.
             description: Condenser temperature in degree Celsius


### PR DESCRIPTION
## Summary

Removes `stiebeleltron_general_temperature_outside` as it's not actually in the general category

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
