### PR TITLE
Add systemd unit files to deb/rpm packager

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,6 +42,12 @@ nfpms:
     formats:
       - deb
       - rpm
+    contents:
+      - src: examples/systemd.service
+        dst: /lib/systemd/system/stiebeleltron-exporter.service
+      - src: examples/systemd.env
+        dst: /etc/default/stiebeleltron-exporter
+        type: config
 
 release:
   prerelease: auto

--- a/README.adoc
+++ b/README.adoc
@@ -26,12 +26,23 @@ It has been tested with ISG 10.2.0.
 
 == Installing
 
-=== Traditional packages or binary
 
-. Download latest binary or package from the https://github.com/ccremer/stiebeleltron-exporter/releases[Releases page]
+=== Binary
+
+. Download latest binary from the https://github.com/ccremer/stiebeleltron-exporter/releases[Releases page]
+. `chmod +x stiebeleltron-exporter && mv stiebeleltron-exporter /usr/local/bin/`
+
+=== Package
+
+Comes with systemd unit file.
+
+. Download latest package from the https://github.com/ccremer/stiebeleltron-exporter/releases[Releases page]
 . `dpkg -i stiebeleltron-exporter_linux_amd64.deb` (Debian/Ubuntu)
 . `rpm -i stiebeleltron-exporter_linux_amd64.rpm` (CentOS)
-. `chmod +x stiebeleltron-exporter && mv stiebeleltron-exporter /usr/local/bin/`
+. `sudo systemctl daemon-reload`
+. Edit the settings in `/etc/default/stiebeleltron-exporter`
+. `sudo systemctl enable stiebeleltron-exporter`
+. `sudo systemctl restart stiebeleltron-exporter`
 
 === Docker
 
@@ -39,7 +50,10 @@ It has been tested with ISG 10.2.0.
 
 === Helm Chart
 
-_not yet existing_
+With https://ccremer.github.io/charts/stiebeleltron-exporter[stiebeleltron-exporter]
+
+. `helm repo add ccremer https://ccremer.github.io/charts`
+. `helm install stiebeleltron ccremer/stiebeleltron-exporter`
 
 == Usage
 
@@ -58,10 +72,6 @@ Upon each call to `/metrics`, the exporter will do GET requests on the given URL
 All flags are also configurable with Environment variables.
 Replace the `.` char with `_` and uppercase the names in order for them to be recognized, e.g. `--log.level debug` becomes `LOG_LEVEL=debug`.
 CLI flags take precedence though.
-
-== As a client API
-
-See link:examples/client.go[Example]
 
 == Developing
 

--- a/examples/systemd.env
+++ b/examples/systemd.env
@@ -1,0 +1,21 @@
+## IP Address to bind to listen for Prometheus scrapes.
+BINDADDR=:9089
+
+## Target URL of Stiebel Eltron ISG device
+ISG_URL=http://isg.ip.or.hostname
+
+## Configuration file that may hold translations of metric names.
+## Accepts full and relative path to a .yaml file.
+## If empty, embedded defaults in English are used.
+#ISG_DEFINITIONPATH=
+
+## Comma-separated list of "key: value" headers to append to the requests going to Stiebel Eltron ISG.
+## Example: "authorization=Basic <base64>".
+#ISG_HEADER=
+
+## Timeout in seconds when collecting metrics from Stiebel Eltron ISG.
+## Should not be larger than the scrape interval.
+#ISG_TIMEOUT=5
+
+## Logging level.
+#LOG_LEVEL=info

--- a/examples/systemd.service
+++ b/examples/systemd.service
@@ -1,0 +1,16 @@
+# This is a systemd unit file
+[Unit]
+Description=Prometheus Exporter for Stiebel-Eltron ISG Heat Pump
+Documentation=https://github.com/ccremer/stiebeleltron-exporter
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+EnvironmentFile=-/etc/default/stiebeleltron-exporter
+User=65534
+Group=0
+ExecStart=/usr/bin/stiebeleltron-exporter
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary


* Adds a system unit file to deb/rpm packages
* Adds a config file in `/etc/default/stiebeleltron-exporter`


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.


<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
