### PR TITLE
Enable multi-arch builds, stop supporting quay.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
@@ -41,13 +47,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to quay.io
-        uses: docker/login-action@v2
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_IO_USER }}
-          password: ${{ secrets.QUAY_IO_PASSWORD }}
 
       - name: Build changelog from PRs with labels
         id: build_changelog
@@ -68,3 +67,4 @@ jobs:
           args: release --release-notes .github/release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_REPOSITORY: ${{ github.repository }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,8 +5,12 @@ builds:
       - CGO_ENABLED=0 # this is needed otherwise the Docker image build is faulty
     goarch:
       - amd64
+      - arm64
+      - arm
     goos:
       - linux
+    goarm:
+      - 7
 
 archives:
   - format: binary
@@ -23,14 +27,42 @@ signs:
     args: ["-u", "8DB7AF3F5520B923DACB3DC15703DBD91B244ED4", "--output", "${signature}", "--detach-sign", "${artifact}"]
 
 dockers:
-  - image_templates:
-      - "quay.io/ccremer/stiebeleltron-exporter:v{{ .Version }}"
-      - "ghcr.io/ccremer/stiebeleltron-exporter:v{{ .Version }}"
+  - goarch: amd64
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+    image_templates:
+      - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
 
-        # For prereleases, updating `latest` does not make sense.
-      # Only the image for the exact version should be pushed.
-      - "{{ if not .Prerelease }}quay.io/ccremer/stiebeleltron-exporter:latest{{ end }}"
-      - "{{ if not .Prerelease }}ghcr.io/ccremer/stiebeleltron-exporter:latest{{ end }}"
+  - goarch: arm64
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+    image_templates:
+      - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
+
+  - goarch: arm
+    goarm: "7"
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm/v7"
+    image_templates:
+      - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-armv7"
+
+docker_manifests:
+  # For prereleases, updating `latest` does not make sense.
+  # Only the image for the exact version should be pushed.
+  - name_template: "{{ if not .Prerelease }}ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:latest{{ end }}"
+    image_templates:
+      - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
+      - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
+      - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-armv7"
+
+  - name_template: "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}"
+    image_templates:
+      - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
+      - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
+      - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-armv7"
 
 nfpms:
   - vendor: ccremer


### PR DESCRIPTION
## Summary

* Enables builds for armv7, arm64 builds
* Make use of Docker manifest

This PR stops pushing docker images to quay.io.
Existing image tags will remain for an undetermined time for now.
Only `ghcr.io` registry is supported.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
