### PR TITLE
Fix parsing of BINDADDR env var

### DIFF
--- a/cfg/types.go
+++ b/cfg/types.go
@@ -20,7 +20,7 @@ type (
 			Headers        []string `koanf:"header"`
 			DefinitionPath string
 		}
-		BindAddr string
+		BindAddr string `koanf:"bindaddr"`
 	}
 	MetricDefinitions struct {
 		Pages map[string]Page


### PR DESCRIPTION
## Summary

exporting `BINDADDR` didn't have an effect. This PR fixes that.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
